### PR TITLE
Add browserify support, fixes: #3

### DIFF
--- a/andlog.js
+++ b/andlog.js
@@ -1,8 +1,9 @@
 // follow @HenrikJoreteg and @andyet if you like this ;)
 (function (window) {
-    var ls = window.localStorage,
+    var global = global || window,
+        ls = global && global.localStorage,
         out = {},
-        inNode = typeof process !== 'undefined';
+        inNode = !ls;
 
     if (inNode) {
         module.exports = console;

--- a/node-test.js
+++ b/node-test.js
@@ -1,5 +1,5 @@
-var logger = require("./&log");
+var logger = require("./andlog");
 
-logger.log("hellow");
+logger.log("hello");
 
 console.log(logger);

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>&amp;log</title>
-<script src="&log.js"></script>
+<script src="andlog.js"></script>
 <script>console.log('hello');</script>


### PR DESCRIPTION
This was a little tricky to get my head around, but this works in browser with and without browserify, and in node, as expected.

It works because:

1) In node: global is defined, but it is different to `this` within the module. Also `global.global === global`
2) In browser w/ browserify: global is defined, and is the same as window
3) In browser standalone: global is undefined, unless the user has set it manually.
