### PR TITLE
Stub out window.console in commonjs environments

### DIFF
--- a/andlog.js
+++ b/andlog.js
@@ -21,9 +21,14 @@
             out[methods[l]] = fn;
         }
     }
+
     if (typeof exports !== 'undefined') {
         module.exports = out;
     } else {
+        window.console = out;
+    }
+
+    if (!inNode && !window.console) {
         window.console = out;
     }
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "andlog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "description": "Super-simple, client-side CommonJS logging thingy",
   "contributors": [


### PR DESCRIPTION
- I'm using commonjs for application logging in the browser, e.g. `var logger = require('andlog').info('App started');` :thumbsup:
- But often use `window.console.log` for dirty debugging, e.g. `console.log('----> HERE <----');` :blush:
- During development I often test in browsers which don't support `window.console` === :boom:

This commit ensures `window.console` is always defined but deliberately doesn't respect the debugging config in local storage, i.e. in a commonjs env the exported console will only log when `localStorage.debug` is truthy but `console.log('----> HERE <----');` just works as expected.
