### PR TITLE
[Fix] check localStorage with try&catch

### DIFF
--- a/andlog.js
+++ b/andlog.js
@@ -1,7 +1,17 @@
 // follow @HenrikJoreteg and @andyet if you like this ;)
 (function () {
+    function checkLocalStorageSafely() {
+        var hasLocalStorage = true;
+        try {
+            hasLocalStorage = !!window.localStorage;
+        } catch (e) {
+            hasLocalStorage = false;
+        }
+        return hasLocalStorage;
+    }
+
     var inNode = typeof window === 'undefined',
-        ls = !inNode && window.localStorage,
+        ls = !inNode && checkLocalStorageSafely(),
         out = {};
 
     if (inNode) {

--- a/andlog.js
+++ b/andlog.js
@@ -1,11 +1,11 @@
 // follow @HenrikJoreteg and @andyet if you like this ;)
 (function () {
     function checkLocalStorageSafely() {
-        var hasLocalStorage = true;
+        var hasLocalStorage = false;
         try {
             hasLocalStorage = !!window.localStorage;
         } catch (e) {
-            hasLocalStorage = false;
+            // failed: access to localStorage is denied
         }
         return hasLocalStorage;
     }

--- a/andlog.js
+++ b/andlog.js
@@ -1,17 +1,17 @@
 // follow @HenrikJoreteg and @andyet if you like this ;)
 (function () {
-    function checkLocalStorageSafely() {
-        var hasLocalStorage = false;
+    function getLocalStorageSafely() {
+        var localStorage;
         try {
-            hasLocalStorage = !!window.localStorage;
+            localStorage = window.localStorage;
         } catch (e) {
             // failed: access to localStorage is denied
         }
-        return hasLocalStorage;
+        return localStorage;
     }
 
     var inNode = typeof window === 'undefined',
-        ls = !inNode && checkLocalStorageSafely(),
+        ls = !inNode && getLocalStorageSafely(),
         out = {};
 
     if (inNode) {


### PR DESCRIPTION
Chrome is throwing an error when both localStorage and _cookies are disabled by the user._

![image](https://user-images.githubusercontent.com/5261748/35275676-d3ee9ac8-0040-11e8-8653-67a97d8814b0.png)
```
Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```
(Chrome, Version 63.0.3239.132 (Official Build) (64-bit), OSX)

To circumvent this, we use try&catch to check for the localStorage.