### PR TITLE
Check if localStorage is available to prevent error, if user has cookies/localStorage disabled.

### DIFF
--- a/andlog.js
+++ b/andlog.js
@@ -14,7 +14,7 @@
         ls = !inNode && getLocalStorageSafely(),
         out = {};
 
-    if (inNode) {
+    if (inNode || !ls) {
         module.exports = console;
         return;
     }


### PR DESCRIPTION
Hi there

This PR is related to the PR https://github.com/HenrikJoreteg/andlog/pull/9.
Even if we catch localStorage, we still have a problem when trying to read andlogKey from `ls` if this is undefined.

So I added a simple check to see if `ls` is defined.